### PR TITLE
Member 도메인 관련 기능 러프 추가

### DIFF
--- a/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberController.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberController.java
@@ -1,0 +1,43 @@
+package org.ktc2.cokaen.wouldyouin.controller.member;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.global.ApiResponseBody;
+import org.ktc2.cokaen.wouldyouin.global.annotation.Authorize;
+import org.ktc2.cokaen.wouldyouin.service.MemberService;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("{memberId}")
+    public ApiResponseBody<?> findMember(@PathVariable("memberId") UUID memberId) {
+        return new ApiResponseBody<>(true, memberService.getById(memberId));
+    }
+
+    @PostMapping
+    public ApiResponseBody<?> createMember(@RequestBody MemberCreateRequest createRequest) {
+        return new ApiResponseBody<>(true, memberService.createMember(createRequest));
+    }
+
+    @PutMapping
+    public ApiResponseBody<?> modifyMember(@Authorize UUID memberId, @RequestBody MemberEditRequest editRequest) {
+        return new ApiResponseBody<>(true, memberService.modifyMember(memberId, editRequest));
+    }
+
+    @DeleteMapping
+    public void deleteMember(@Authorize UUID memberId) {
+        memberService.deleteMemberById(memberId);
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberCreateRequest.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberCreateRequest.java
@@ -1,0 +1,21 @@
+package org.ktc2.cokaen.wouldyouin.controller.member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.domain.Area;
+import org.ktc2.cokaen.wouldyouin.domain.Member;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberCreateRequest {
+
+    private final String nickname;
+    private final Area area;
+
+    public Member toEntity() {
+        return Member.builder()
+            .nickname(this.nickname)
+            .area(this.area)
+            .build();
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberEditRequest.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberEditRequest.java
@@ -1,0 +1,19 @@
+package org.ktc2.cokaen.wouldyouin.controller.member;
+
+import jakarta.annotation.Nullable;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.domain.Area;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberEditRequest {
+
+    @Nullable private final String nickname;
+    @Nullable private final Area area;
+    @Nullable private final String phoneNumber;
+    @Nullable private final String profileUrl;
+    @Nullable private final String intro;
+    @Nullable private final String hashtag;
+    @Nullable private final String curatorProfileUrl;
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberResponse.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/controller/member/MemberResponse.java
@@ -1,0 +1,42 @@
+package org.ktc2.cokaen.wouldyouin.controller.member;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import org.ktc2.cokaen.wouldyouin.domain.Area;
+import org.ktc2.cokaen.wouldyouin.domain.Member;
+
+@Getter
+@Builder
+public class MemberResponse {
+
+    private UUID memberId;
+    private String nickname;
+    private Area area;
+    private String gender;
+    private String phoneNumber;
+    private String profileUrl;
+    private String memberType;
+
+    private String intro;
+    private Integer number;
+    private List<String> hashtag;
+    private String curatorProfileUrl;
+
+    public static MemberResponse from(final Member member) {
+        return MemberResponse.builder()
+            .memberId(member.getId())
+            .nickname(member.getNickname())
+            .area(member.getArea())
+            .gender(member.getGender())
+            .phoneNumber(member.getPhone())
+            .profileUrl(member.getProfileImageUrl())
+            .memberType(member.getUserType())
+            .intro(null)
+            .number(null)
+            .hashtag(null)
+            .curatorProfileUrl(null)
+            .build();
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/domain/Member.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/domain/Member.java
@@ -1,0 +1,36 @@
+package org.ktc2.cokaen.wouldyouin.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+public class Member {
+
+    @Column
+    @Id
+    private UUID id;
+    @Column(nullable = false)
+    private String nickname;
+    @Column(nullable = false)
+    private Area area;
+    @Column(nullable = false)
+    private String userType;
+    @Column(nullable = false)
+    private String gender;
+    @Column
+    private String phone;
+    @Column
+    private String profileImageUrl;
+
+    protected Member() {
+
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/global/ApiResponseBody.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/global/ApiResponseBody.java
@@ -1,12 +1,10 @@
-package org.ktc2.cokaen.wouldyouin.controller.event.response;
+package org.ktc2.cokaen.wouldyouin.global;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-//globalwouldyouin.global.ApiResponseBody로 사용 필요
-@Deprecated
 public class ApiResponseBody<D> {
 
     private final Boolean status;

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/global/WebConfig.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/global/WebConfig.java
@@ -1,0 +1,23 @@
+package org.ktc2.cokaen.wouldyouin.global;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.global.annotation.AuthorizeArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthorizeArgumentResolver authorizeArgumentResolver;
+
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authorizeArgumentResolver);
+    }
+
+
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/global/annotation/Authorize.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/global/annotation/Authorize.java
@@ -1,0 +1,11 @@
+package org.ktc2.cokaen.wouldyouin.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorize {
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/global/annotation/AuthorizeArgumentResolver.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/global/annotation/AuthorizeArgumentResolver.java
@@ -1,0 +1,39 @@
+package org.ktc2.cokaen.wouldyouin.global.annotation;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.global.util.JwtManager;
+import org.ktc2.cokaen.wouldyouin.service.MemberService;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizeArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtManager jwtManager;
+    private final MemberService memberService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Authorize.class)
+            && parameter.getParameterType().isAssignableFrom(UUID.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory) throws Exception {
+        // Authorization 헤더에서 Bearer 토큰 추출
+        String authorizationHeader = webRequest.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new RuntimeException("Authorization header is missing or invalid");
+        }
+
+        // ID의 실제 검증은 컨트롤러로 넘어간 후 MemberService에서 진행
+        return jwtManager.getMemberFromToken(authorizationHeader.substring(7));
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/global/util/JwtManager.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/global/util/JwtManager.java
@@ -1,0 +1,20 @@
+package org.ktc2.cokaen.wouldyouin.global.util;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.domain.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+//TODO: 토큰처리 로직추가
+public class JwtManager {
+
+    public String getTokenFromMember(Member member) {
+        return member.getId().toString();
+    }
+
+    public UUID getMemberFromToken(String token) {
+        return UUID.fromString(token);
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/repository/MemberRepository.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package org.ktc2.cokaen.wouldyouin.repository;
+
+import java.util.UUID;
+import org.ktc2.cokaen.wouldyouin.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/service/MemberService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/service/MemberService.java
@@ -1,0 +1,55 @@
+package org.ktc2.cokaen.wouldyouin.service;
+
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.controller.member.MemberCreateRequest;
+import org.ktc2.cokaen.wouldyouin.controller.member.MemberEditRequest;
+import org.ktc2.cokaen.wouldyouin.controller.member.MemberResponse;
+import org.ktc2.cokaen.wouldyouin.domain.Member;
+import org.ktc2.cokaen.wouldyouin.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberResponse getById(UUID id) {
+        return MemberResponse.from(findMemberOrThrow(id));
+    }
+
+    @Transactional
+    public MemberResponse createMember(MemberCreateRequest request) {
+        return MemberResponse.from(memberRepository.save(request.toEntity()));
+    }
+
+    @Transactional
+    public MemberResponse modifyMember(UUID memberId, MemberEditRequest editRequest) {
+        Member member = findMemberOrThrow(memberId);
+        Optional.ofNullable(editRequest.getNickname()).ifPresent(member::setNickname);
+        Optional.ofNullable(editRequest.getArea()).ifPresent(member::setArea);
+        Optional.ofNullable(editRequest.getPhoneNumber()).ifPresent(member::setPhone);
+        Optional.ofNullable(editRequest.getProfileUrl()).ifPresent(member::setProfileImageUrl);
+
+        //TODO: 일반사용자가 아닌 경우 처리 필요
+        Optional.ofNullable(editRequest.getIntro()).ifPresent(m -> {});
+        Optional.ofNullable(editRequest.getHashtag()).ifPresent(m -> {});
+        Optional.ofNullable(editRequest.getCuratorProfileUrl()).ifPresent(m -> {});
+
+        return MemberResponse.from(member);
+    }
+
+    @Transactional
+    public void deleteMemberById(UUID memberId) {
+        memberRepository.delete(findMemberOrThrow(memberId));
+    }
+
+    @Transactional(readOnly = true)
+    protected Member findMemberOrThrow(UUID id) {
+        return memberRepository.findById(id).orElseThrow(RuntimeException::new);
+    }
+}


### PR DESCRIPTION

### 변경사항
- `ApiResponseBody` 를 global 패키지로 이동
  - 기존 클래스(`controller.event.response.ApiResponseBody`)는 `@Deprecated` 처리

### 추가사항
- Member 도메인 관련 Entity, Repository, Service, Controller, DTO 추가
- Authorization 헤더가 필요한 API에 대해 커스텀 어노테이션 구현 후 추가
- JWT 매니저 껍데기 추가
  - 실제 기능 구현 필요

### TODO
- JWT 구현하기
- Spring Security? 써서 인증/인가 구현하기
- Enum 관련 처리 추가필요
- ExceptionHandler 추가필요