### PR TITLE
[Weekly/7/Refactor/MemberFactory] 멤버 팩토리에서 빈 의존성 제거 및 기타 리팩터링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### static images
+/src/main/resources/staticimages/

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/Image/application/MemberImageService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/Image/application/MemberImageService.java
@@ -53,6 +53,10 @@ public class MemberImageService extends ImageService<MemberImage>
     @Override
     // TODO: imageUrl을 MemberImage로 변환하는 로직 추가 필요
     public List<MemberImage> convert(String imageUrl) {
-        return null;
+        return List.of(MemberImage.builder()
+            .name("http://example.com/images/MockMemberImageUrl")
+            .size(10L)
+            .extension(".jpeg")
+            .build());
     }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/like/application/CuratorLikeService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/like/application/CuratorLikeService.java
@@ -1,10 +1,10 @@
 package org.ktc2.cokaen.wouldyouin.like.application;
 
-import java.util.Map;
 import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
 import org.ktc2.cokaen.wouldyouin.like.persist.CuratorLike;
 import org.ktc2.cokaen.wouldyouin.like.persist.CuratorLikeRepository;
 import org.ktc2.cokaen.wouldyouin.like.persist.LikeRepository;
+import org.ktc2.cokaen.wouldyouin.member.application.LikeableMemberGetterFactory;
 import org.ktc2.cokaen.wouldyouin.member.persist.Curator;
 import org.ktc2.cokaen.wouldyouin.member.persist.LikeableMember;
 import org.ktc2.cokaen.wouldyouin.member.persist.Member;
@@ -17,9 +17,9 @@ public class CuratorLikeService extends LikeService<CuratorLike> {
     private final CuratorLikeRepository curatorLikeRepository;
 
     public CuratorLikeService(
-        Map<String, EntityGettable<Long, ? extends LikeableMember>> likeableMemberGetter, EntityGettable<Long, Member> memberGetter,
-        CuratorLikeRepository curatorLikeRepository) {
-        super(likeableMemberGetter, memberGetter);
+        LikeableMemberGetterFactory likeableMemberGetterFactory,
+        EntityGettable<Long, Member> memberGetter, CuratorLikeRepository curatorLikeRepository) {
+        super(likeableMemberGetterFactory, memberGetter);
         this.curatorLikeRepository = curatorLikeRepository;
     }
 

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/like/application/HostLikeService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/like/application/HostLikeService.java
@@ -1,10 +1,10 @@
 package org.ktc2.cokaen.wouldyouin.like.application;
 
-import java.util.Map;
 import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
 import org.ktc2.cokaen.wouldyouin.like.persist.HostLike;
 import org.ktc2.cokaen.wouldyouin.like.persist.HostLikeRepository;
 import org.ktc2.cokaen.wouldyouin.like.persist.LikeRepository;
+import org.ktc2.cokaen.wouldyouin.member.application.LikeableMemberGetterFactory;
 import org.ktc2.cokaen.wouldyouin.member.persist.Host;
 import org.ktc2.cokaen.wouldyouin.member.persist.LikeableMember;
 import org.ktc2.cokaen.wouldyouin.member.persist.Member;
@@ -17,9 +17,9 @@ public class HostLikeService extends LikeService<HostLike> {
     private final HostLikeRepository hostLikeRepository;
 
     public HostLikeService(
-        Map<String, EntityGettable<Long, ? extends LikeableMember>> likeableMemberGetter, EntityGettable<Long, Member> memberGetter,
-        HostLikeRepository hostLikeRepository) {
-        super(likeableMemberGetter, memberGetter);
+        LikeableMemberGetterFactory likeableMemberGetterFactory,
+        EntityGettable<Long, Member> memberGetter, HostLikeRepository hostLikeRepository) {
+        super(likeableMemberGetterFactory, memberGetter);
         this.hostLikeRepository = hostLikeRepository;
     }
 

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/like/application/LikeService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/like/application/LikeService.java
@@ -1,11 +1,11 @@
 package org.ktc2.cokaen.wouldyouin.like.application;
 
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
 import org.ktc2.cokaen.wouldyouin.like.persist.Like;
 import org.ktc2.cokaen.wouldyouin.like.persist.LikeRepository;
+import org.ktc2.cokaen.wouldyouin.member.application.LikeableMemberGetterFactory;
 import org.ktc2.cokaen.wouldyouin.member.persist.LikeableMember;
 import org.ktc2.cokaen.wouldyouin.member.persist.Member;
 import org.ktc2.cokaen.wouldyouin.member.persist.MemberType;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public abstract class LikeService<LikeType extends Like<? extends LikeableMember>> {
 
-    private final Map<String, EntityGettable<Long, ? extends LikeableMember>> likeableMemberGetter;
+    private final LikeableMemberGetterFactory likeableMemberGetterFactory;
     private final EntityGettable<Long, Member> memberGetter;
 
     protected abstract LikeRepository<LikeType> getLikeRepository();
@@ -58,6 +58,6 @@ public abstract class LikeService<LikeType extends Like<? extends LikeableMember
 
     @Transactional(readOnly = true)
     protected LikeableMember getLikeableMemberByIdOrThrow(Long likeableMemberId) {
-        return likeableMemberGetter.get(getTargetLikeableMemberType().getServiceName()).getByIdOrThrow(likeableMemberId);
+        return likeableMemberGetterFactory.get(getTargetLikeableMemberType()).getByIdOrThrow(likeableMemberId);
     }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/CuratorService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/CuratorService.java
@@ -10,12 +10,13 @@ import org.ktc2.cokaen.wouldyouin.member.persist.Curator;
 import org.ktc2.cokaen.wouldyouin.member.persist.CuratorRepository;
 import org.ktc2.cokaen.wouldyouin.member.persist.Member;
 import org.ktc2.cokaen.wouldyouin.member.persist.MemberRepository;
+import org.ktc2.cokaen.wouldyouin.member.persist.MemberType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class CuratorService implements MemberServiceCommonBehavior, EntityGettable<Long, Curator> {
+public class CuratorService implements MemberServiceCommonBehavior, EntityGettable<Long, Curator>, LikeableMemberService<Curator> {
 
     private final CuratorRepository curatorRepository;
     private final MemberRepository memberRepository;
@@ -81,4 +82,13 @@ public class CuratorService implements MemberServiceCommonBehavior, EntityGettab
         return curatorRepository.findById(id).orElseThrow(RuntimeException::new);
     }
 
+    @Override
+    public MemberType getTargetMemberType() {
+        return MemberType.curator;
+    }
+
+    @Override
+    public EntityGettable<Long, Curator> getLikeableMemberGetter() {
+        return this;
+    }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/CuratorService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/CuratorService.java
@@ -1,7 +1,9 @@
 package org.ktc2.cokaen.wouldyouin.member.application;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.Image.persist.MemberImage;
 import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
 import org.ktc2.cokaen.wouldyouin.member.application.dto.request.edit.CuratorEditRequest;
 import org.ktc2.cokaen.wouldyouin.member.application.dto.MemberResponse;
@@ -21,6 +23,7 @@ public class CuratorService implements MemberServiceCommonBehavior, EntityGettab
     private final CuratorRepository curatorRepository;
     private final MemberRepository memberRepository;
     private final BaseMemberRepository baseMemberRepository;
+    private final EntityGettable<List<Long>, List<MemberImage>> imageIdToMemberImageConverter;
 
     @Transactional
     public MemberResponse createCurator(Long normalMemberId) {
@@ -54,11 +57,15 @@ public class CuratorService implements MemberServiceCommonBehavior, EntityGettab
     @Transactional
     public MemberResponse updateCurator(Long curatorId, CuratorEditRequest request) {
         Curator curator = getByIdOrThrow(curatorId);
-        Optional.ofNullable(curator.getNickname()).ifPresent(curator::setNickname);
-        Optional.ofNullable(curator.getPhone()).ifPresent(curator::setPhone);
-        Optional.ofNullable(curator.getProfileImage()).ifPresent(curator::setProfileImage);
-        Optional.ofNullable(curator.getArea()).ifPresent(curator::setArea);
-        Optional.ofNullable(curator.getIntro()).ifPresent(curator::setIntro);
+
+        Optional.ofNullable(request.getPhoneNumber()).ifPresent(curator::setPhone);
+        Optional.ofNullable(request.getNickname()).ifPresent(curator::setNickname);
+        Optional.ofNullable(request.getArea()).ifPresent(curator::setArea);
+        Optional.ofNullable(request.getIntro()).ifPresent(curator::setIntro);
+        Optional.ofNullable(request.getProfileImageId())
+            .map(List::of)
+            .map(imageIdToMemberImageConverter::getByIdOrThrow)
+            .ifPresent(curator::setProfileImage);
 
         return MemberResponse.from(curator);
     }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/LikeableMemberGetterFactory.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/LikeableMemberGetterFactory.java
@@ -1,0 +1,27 @@
+package org.ktc2.cokaen.wouldyouin.member.application;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
+import org.ktc2.cokaen.wouldyouin.member.persist.LikeableMember;
+import org.ktc2.cokaen.wouldyouin.member.persist.MemberType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LikeableMemberGetterFactory {
+
+    private final Map<MemberType, EntityGettable<Long, ? extends LikeableMember>> map;
+
+    public LikeableMemberGetterFactory(@Autowired List<LikeableMemberService<? extends LikeableMember>> likeableMemberServices) {
+        map = likeableMemberServices.stream()
+            .collect(Collectors.toConcurrentMap(
+                LikeableMemberService::getTargetMemberType,
+                LikeableMemberService::getLikeableMemberGetter));
+    }
+
+    public EntityGettable<Long, ? extends LikeableMember> get(MemberType memberType) {
+        return map.get(memberType);
+    }
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/LikeableMemberService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/LikeableMemberService.java
@@ -1,0 +1,13 @@
+package org.ktc2.cokaen.wouldyouin.member.application;
+
+import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
+import org.ktc2.cokaen.wouldyouin.member.persist.LikeableMember;
+import org.ktc2.cokaen.wouldyouin.member.persist.MemberType;
+
+public interface LikeableMemberService<T extends LikeableMember> {
+
+    MemberType getTargetMemberType();
+
+    EntityGettable<Long, T> getLikeableMemberGetter();
+
+}

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/MemberService.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/MemberService.java
@@ -35,8 +35,10 @@ public class MemberService implements MemberServiceCommonBehavior, EntityGettabl
         Optional.ofNullable(editRequest.getNickname()).ifPresent(member::setNickname);
         Optional.ofNullable(editRequest.getArea()).ifPresent(member::setArea);
         Optional.ofNullable(editRequest.getPhoneNumber()).ifPresent(member::setPhone);
-        Optional.ofNullable(editRequest.getProfileImage())
-            .map(imageIdToMemberImageConverter::getByIdOrThrow).ifPresent(member::setProfileImage);
+        Optional.ofNullable(editRequest.getProfileImageId())
+            .map(List::of)
+            .map(imageIdToMemberImageConverter::getByIdOrThrow)
+            .ifPresent(member::setProfileImage);
 
         return MemberResponse.from(member);
     }
@@ -74,5 +76,10 @@ public class MemberService implements MemberServiceCommonBehavior, EntityGettabl
     @Transactional(readOnly = true)
     public Optional<MemberIdentifier> getMemberIdentifierBySocialId(String socialId) {
         return memberRepository.findBySocialId(socialId).map(m -> new MemberIdentifier(m.getId(), m.getMemberType()));
+    }
+
+    @Override
+    public MemberType getTargetMemberType() {
+        return MemberType.normal;
     }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/MemberServiceCommonBehavior.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/MemberServiceCommonBehavior.java
@@ -1,6 +1,7 @@
 package org.ktc2.cokaen.wouldyouin.member.application;
 
 import org.ktc2.cokaen.wouldyouin.member.application.dto.MemberResponse;
+import org.ktc2.cokaen.wouldyouin.member.persist.MemberType;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface MemberServiceCommonBehavior {
@@ -10,4 +11,6 @@ public interface MemberServiceCommonBehavior {
 
     @Transactional(readOnly = true)
     MemberResponse getMemberResponseById(Long id);
+
+    MemberType getTargetMemberType();
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/create/HostCreateRequest.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/create/HostCreateRequest.java
@@ -1,7 +1,10 @@
 package org.ktc2.cokaen.wouldyouin.member.application.dto.request.create;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.ktc2.cokaen.wouldyouin.Image.persist.MemberImage;
+import org.ktc2.cokaen.wouldyouin._common.api.EntityGettable;
 import org.ktc2.cokaen.wouldyouin.member.persist.Host;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -11,16 +14,19 @@ public class HostCreateRequest extends MemberCreateRequestBase {
 
     protected String phone;
     protected String password;
+    protected Long profileImageId;
 
-    public HostCreateRequest(String nickname, String email, String phone, String password) {
+    public HostCreateRequest(String nickname, String email, String phone, String password, Long profileImageId) {
         super(nickname, email);
         this.phone = phone;
         this.password = password;
+        this.profileImageId = profileImageId;
     }
 
-    public Host toEntity(PasswordEncoder passwordEncoder) {
+    public Host toEntity(PasswordEncoder passwordEncoder, EntityGettable<List<Long>, List<MemberImage>> imageIdToMemberImageConverter) {
         return Host.builder()
             .nickname(this.nickname)
+            .profileImage(imageIdToMemberImageConverter.getByIdOrThrow(List.of(this.profileImageId)))
             .email(this.email)
             .phone(this.phone)
             .hashedPassword(passwordEncoder.encode(this.password))

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/CuratorEditRequest.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/CuratorEditRequest.java
@@ -1,7 +1,6 @@
 package org.ktc2.cokaen.wouldyouin.member.application.dto.request.edit;
 
 import io.micrometer.common.lang.Nullable;
-import java.util.List;
 import lombok.Getter;
 import org.ktc2.cokaen.wouldyouin._common.persist.Area;
 
@@ -10,8 +9,8 @@ public class CuratorEditRequest extends MemberEditRequest {
 
     @Nullable private final String intro;
 
-    public CuratorEditRequest(@Nullable String nickname, @Nullable String phoneNumber, @Nullable List<Long> profileImage, @Nullable Area area, @Nullable String intro) {
-        super(nickname, phoneNumber, profileImage, area);
+    public CuratorEditRequest(@Nullable String nickname, @Nullable String phoneNumber, @Nullable Long profileImageId, @Nullable Area area, @Nullable String intro) {
+        super(nickname, phoneNumber, profileImageId, area);
         this.intro = intro;
     }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/HostEditRequest.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/HostEditRequest.java
@@ -2,7 +2,6 @@ package org.ktc2.cokaen.wouldyouin.member.application.dto.request.edit;
 
 
 import jakarta.annotation.Nullable;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,9 +12,9 @@ public class HostEditRequest extends MemberEditRequestBase {
     @Nullable  private final String hashtag;
 
     @Builder
-    public HostEditRequest(@Nullable String nickname, @Nullable String phoneNumber, @Nullable List<Long> profileImage,
+    public HostEditRequest(@Nullable String nickname, @Nullable String phoneNumber, @Nullable Long profileImageId,
         @Nullable String intro, @Nullable String hashtag) {
-        super(nickname, phoneNumber, profileImage);
+        super(nickname, phoneNumber, profileImageId);
         this.intro = intro;
         this.hashtag = hashtag;
     }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/MemberEditRequest.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/MemberEditRequest.java
@@ -1,7 +1,6 @@
 package org.ktc2.cokaen.wouldyouin.member.application.dto.request.edit;
 
 import jakarta.annotation.Nullable;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.ktc2.cokaen.wouldyouin._common.persist.Area;
@@ -12,8 +11,8 @@ public class MemberEditRequest extends MemberEditRequestBase {
     @Nullable private final Area area;
 
     @Builder
-    public MemberEditRequest(@Nullable String nickname, @Nullable String phoneNumber, @Nullable List<Long> profileImage, @Nullable Area area) {
-        super(nickname, phoneNumber, profileImage);
+    public MemberEditRequest(@Nullable String nickname, @Nullable String phoneNumber, @Nullable Long profileImageId, @Nullable Area area) {
+        super(nickname, phoneNumber, profileImageId);
         this.area = area;
     }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/MemberEditRequestBase.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/application/dto/request/edit/MemberEditRequestBase.java
@@ -1,7 +1,6 @@
 package org.ktc2.cokaen.wouldyouin.member.application.dto.request.edit;
 
 import jakarta.annotation.Nullable;
-import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,5 +10,5 @@ public abstract class MemberEditRequestBase {
 
     @Nullable private final String nickname;
     @Nullable private final String phoneNumber;
-    @Nullable private final List<Long> profileImage;
+    @Nullable private final Long profileImageId;
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/persist/BaseMember.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/persist/BaseMember.java
@@ -16,8 +16,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.ktc2.cokaen.wouldyouin.Image.persist.MemberImage;
 
+@Slf4j
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -60,7 +62,22 @@ public abstract class BaseMember {
         this.profileImage = profileImage;
     }
 
+    @Override
+    public String toString() {
+        return "BaseMember{" +
+            "Id=" + Id +
+            ", accountType=" + accountType +
+            ", memberType=" + memberType +
+            ", email='" + email + '\'' +
+            ", nickname='" + nickname + '\'' +
+            ", phone='" + phone + '\'' +
+            ", profileImage=" + profileImage +
+            '}';
+    }
+
     public String getProfileImageUrl() {
+        // TODO: 멤버 조회시 profileImage에 null 들어가는 원인 파악 필요
+        log.warn("#### in baseMember.getProfileImageUrl() for baseMember: {}", this);
         return profileImage.getFirst().getUrl();
     }
 }

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/persist/Host.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/persist/Host.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.ktc2.cokaen.wouldyouin.Image.persist.MemberImage;
 import org.ktc2.cokaen.wouldyouin.event.persist.Event;
 
 @Getter
@@ -35,8 +36,8 @@ public class Host extends BaseMember implements LikeableMember {
     private List<Event> events;
 
     @Builder
-    protected Host(String email, String nickname, String phone, String hashedPassword) {
-        super(AccountType.local, MemberType.host, email, nickname, phone, List.of());
+    protected Host(String email, String nickname, String phone, String hashedPassword, List<MemberImage> profileImage) {
+        super(AccountType.local, MemberType.host, email, nickname, phone, profileImage);
         this.hashedPassword = hashedPassword;
         this.intro = "";
         this.likes = 0;

--- a/src/main/java/org/ktc2/cokaen/wouldyouin/member/persist/MemberType.java
+++ b/src/main/java/org/ktc2/cokaen/wouldyouin/member/persist/MemberType.java
@@ -4,16 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum MemberType {
-    welcome("memberService"), // 처음 가입해 추가정보가 필요한 멤버
-    normal("memberService"),
-    curator("curatorService"),
-    host("hostService"),
-    admin("");
-
-    private final String serviceName;
-
-    MemberType(String serviceName) {
-        this.serviceName = serviceName;
-    }
+    welcome, // 처음 가입해 추가정보가 필요한 멤버
+    normal,
+    curator,
+    host,
+    admin;
 
 }

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -12,4 +12,4 @@ spring:
       ddl-auto: none
 
 # log4j log level setting
-logging.level.kr.ac.jnu.capstone.bigpicture.dongsim: info
+logging.level.org.ktc2.cokaen.wouldyouin: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,15 @@ spring:
   application.name: WouldYouIn
   profiles:
     default: dev
+
+  # 소셜로그인 테스트시 캐시 비활성화
   thymeleaf:
     cache: false
+
+  # devtools 자동 빌드 해제
+  devtools:
+    restart:
+      enabled: false
 
   # h2 database settings
   h2:


### PR DESCRIPTION
## 🔥 Pull requests

🌳 **작업 브랜치**

- Refactor/MemberFactory

⚒ **작업 내용**

- MemberType에 빈 이름 의존성을 제거
- 멤버 팩토리에서 빈 이름 의존성 제거
- staticImage가 git에 올라가지 않도록 수정
- 단일 Long 타입 이미지 ID로 멤버 도메인의 프로필을 추가, 수정하는 기능 추가

## ⚠ 참고 사항

- 왜인지 모르겠는데 멤버 조회시 baseMember의 profileImage 필드에 null이 대입되는 현상이 있음
- 추후 원인 파악 후 수정해야 하는 중대사항이나... 시간관계상 생략
- 이슈로 등록하였음 => https://github.com/kakao-tech-campus-2nd-step3/Team26_BE/issues/49

## 📸 스크린샷(선택)

|기능 | 스크린샷 |
| :-: | :------: |
|  |  |
